### PR TITLE
Fix parse_slice for 3-part DAP2 stride constraints

### DIFF
--- a/opendap_protocol/protocol.py
+++ b/opendap_protocol/protocol.py
@@ -529,9 +529,13 @@ def parse_slice(token):
             return ...
         elif ':' in token:
             rng = [int(s) for s in token.split(':')]
-            # The DAP protocol uses slicing including the last index.
-            # [0:20] in DAP translates to [0:21] in Python.
-            rng[1] += 1
+            # DAP2 format: [start:stop] or [start:stride:stop] (inclusive stop)
+            # Python slice: slice(start, stop, stride) (exclusive stop)
+            # Increment the last element (stop) to convert inclusive -> exclusive
+            rng[-1] += 1
+            if len(rng) == 3:
+                # DAP2: [start:stride:stop] -> Python: slice(start, stop+1, stride)
+                rng = [rng[0], rng[2], rng[1]]
             return slice(*rng)
 
 


### PR DESCRIPTION
DAP2 constraint syntax uses [start:stride:stop] (inclusive stop), which must map to Python's slice(start, stop+1, stride).

Previously, parse_slice always incremented rng[1], which is correct for 2-part [start:stop] but wrong for 3-part [start:stride:stop] where rng[1] is the stride. This caused constraints like lat[0:1:17999] to produce slice(0, 2, 4) instead of slice(0, 18000, 1), returning only 1 element instead of the expected 18000.

Fix: increment rng[-1] (always the stop) and reorder the 3-part case from [start, stride, stop] to Python's [start, stop, stride].

Discovered via pydap 3.5 + xpublish_opendap serving an icechunk store.

return 1 element instead of 18000.